### PR TITLE
Pass through command line arguments to Chrome

### DIFF
--- a/app/src/epichrome
+++ b/app/src/epichrome
@@ -1019,11 +1019,11 @@ myEngineExec="$myEngineContents/MacOS/$engineExec"
 if [[ "$newprofile" ]] ; then
     # if we're creating a new profile (first run), run once with a page
     # instructing the user to enable Epichrome Helper
-    myCommand=( "$myEngineExec" --user-data-dir="$myProfilePath" \
+    myCommand=( "$myEngineExec" --user-data-dir="$myProfilePath" "$@" \
 				"file://$myContents/Resources/FirstRun/welcome.html" )
 else
 # normal run -- use the regular command line
-    myCommand=( "$myEngineExec" --user-data-dir="$myProfilePath" "${SSBCommandLine[@]}" )
+    myCommand=( "$myEngineExec" --user-data-dir="$myProfilePath" "$@" "${SSBCommandLine[@]}" )
 fi
 
 


### PR DESCRIPTION
I have the need to specify command line arguments to Chrome at times (such as a --proxy-server) and I would like the ability to do this with Epichrome. This change passes the command line arguments (if any) that were specified when Epichrome was launched on to Chrome.